### PR TITLE
Declare and define AStar::Vec2i::operator+ in header file

### DIFF
--- a/source/AStar.cpp
+++ b/source/AStar.cpp
@@ -9,11 +9,6 @@ bool AStar::Vec2i::operator == (const Vec2i& coordinates_)
     return (x == coordinates_.x && y == coordinates_.y);
 }
 
-AStar::Vec2i operator + (const AStar::Vec2i& left_, const AStar::Vec2i& right_)
-{
-    return{ left_.x + right_.x, left_.y + right_.y };
-}
-
 AStar::Node::Node(Vec2i coordinates_, Node *parent_)
 {
     parent = parent_;

--- a/source/AStar.hpp
+++ b/source/AStar.hpp
@@ -17,6 +17,9 @@ namespace AStar
         int x, y;
 
         bool operator == (const Vec2i& coordinates_);
+        friend Vec2i operator + (const AStar::Vec2i& left_, const AStar::Vec2i& right_) {
+            return{ left_.x + right_.x, left_.y + right_.y };
+        }
     };
 
     using uint = unsigned int;


### PR DESCRIPTION
Vec2i::operator+ is defined and declared here but not declared in the header file, which makes it invisible when the header is included. Declaring it in the AStar::Vec2i struct (in the header) would make it clear that the addition behavior is already implemented and help avoid code duplication.